### PR TITLE
Markdown Typo

### DIFF
--- a/plugins/getting-started.md
+++ b/plugins/getting-started.md
@@ -9,7 +9,7 @@
 - [```.on(event, callback)```](https://github.com/solvedDev/bridge./blob/master/plugins/bridge/on.md)
 - ```.off(event, callback)```
 - [```.open(file)```](https://github.com/solvedDev/bridge./blob/master/plugins/bridge/open.md) **<DEPRECATED!>**
-- .openFile(file_path)
+- ```.openFile(file_path)```
 - [```.openExternal(path)```](https://github.com/solvedDev/bridge./blob/master/plugins/bridge/openExternal.md)
 - [```.registerPlugin(plugin_info)```](https://github.com/solvedDev/bridge./blob/master/plugins/bridge/registerPlugin.md)
 - [```.trigger(event, arguments)```](https://github.com/solvedDev/bridge./blob/master/plugins/bridge/trigger.md)


### PR DESCRIPTION
**<h2>Fixed:</h2>**
- Markdown Typo in "``plugins/getting-started.md``"