### PR TITLE
Draggable JSON nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Additionally, "bridge." has a few specific features which other editors do not o
    - Cut, Copy, Paste, Undo, Redo and all other features you would expect
    - Powerful shortcuts to reorder and navigate through a JSON file
    - JSON displays as a tree structure with collapsible/expandable elements
+   - Easily restructure JSON files by dragging elements
    - Beautiful syntax highlighting for all behavior pack files
    - Snippets to quickly import common JSON patterns
    - Error/Mistake detection and auto-fixes for some of them

--- a/package-lock.json
+++ b/package-lock.json
@@ -3540,7 +3540,7 @@
       }
     },
     "discord-rpc": {
-      "version": "github:discordjs/rpc#2dc7ca3e78d632c07ca965a65ba669afe26fdc7f",
+      "version": "github:discordjs/rpc#3444ac24d2f0d5f52f59207a8759d928207df0ad",
       "from": "github:discordjs/rpc",
       "requires": {
         "node-fetch": "^2.3.0",
@@ -9906,6 +9906,11 @@
         "is-plain-obj": "^1.0.0"
       }
     },
+    "sortablejs": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.9.0.tgz",
+      "integrity": "sha512-Ot6bYJ6PoqPmpsqQYXjn1+RKrY2NWQvQt/o4jfd/UYwVWndyO5EPO8YHbnm5HIykf8ENsm4JUrdAvolPT86yYA=="
+    },
     "source-list-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -11391,6 +11396,14 @@
       "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.6.0.tgz",
       "integrity": "sha512-x3LV3wdmmERhVCYy3quqA57NJW7F3i6faas++pJQWtknWT+n7k30F4TVdHvCLn48peTJFRvCpxs3UuFPqgeELg==",
       "dev": true
+    },
+    "vuedraggable": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/vuedraggable/-/vuedraggable-2.23.0.tgz",
+      "integrity": "sha512-RgdH16k43WNoxyRcv/OarB/DZh9SY5TYthk9TS4YiHXpelD1DytEG0phLAXiXx5EhsmdH8ltSWxklGa4g1WTCw==",
+      "requires": {
+        "sortablejs": "^1.9.0"
+      }
     },
     "vuetify": {
       "version": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "uuid": "^3.3.2",
     "vue": "^2.6.10",
     "vue-electron": "^1.0.6",
+    "vuedraggable": "^2.23.0",
     "vuetify": "^1.2.5",
     "vuex": "^3.1.0",
     "zip-a-folder": "0.0.7"

--- a/src/renderer/components/editor_shell/JsonEditor/Main.vue
+++ b/src/renderer/components/editor_shell/JsonEditor/Main.vue
@@ -2,6 +2,7 @@
     <span>
         <div v-if="open" :style="element_style">
             <span v-if="render_object.type == 'object' || render_object.type == 'array'">
+                <draggable v-model="render_object.children" :options="{ group: 'key' }" @change="draggedKey">
                 <details 
                     v-for="e in render_object.children"
                     :key="e.uuid"
@@ -29,6 +30,7 @@
                         :object_key="`${object_key}/${(e.key + '').replace(/\//g, '#;slash;#')}`"
                     />
                 </details>
+                </draggable>
             </span>
             
             <highlight-attribute 
@@ -84,6 +86,7 @@
     import EventBus from '../../../scripts/EventBus';
     import JSONTree from '../../../scripts/editor/JsonTree';
     import FileType from '../../../scripts/editor/FileType';
+    import draggable from "vuedraggable";
 
     export default {
         name: "json-editor-main",
@@ -91,7 +94,8 @@
             HighlightAttribute,
             ObjectKey,
             JsonInput,
-            PredictingInput
+            PredictingInput,
+            draggable
         },
         props: {
             available_height: Number,
@@ -186,7 +190,7 @@
                 if(event.target.tagName === "I" || event.target.tagName === "BUTTON")
                     return;
                 event.preventDefault();
-                
+
                 let path = `${this.object_key}/${key.replace(/\//g, "#;slash;#")}`;
                 let context = this.render_object.get(key);
                 
@@ -215,6 +219,10 @@
 
                     if(depth == deepest) this.$store.commit("removeLoadingWindow", { id: "open-file" });
                 }, 5);
+            },
+            draggedKey() {
+                TabSystem.setCurrentUnsaved();
+                TabSystem.setCurrentFileNav("global");
             },
 
             isKnownFileType() {

--- a/src/renderer/components/editor_shell/JsonEditor/Main.vue
+++ b/src/renderer/components/editor_shell/JsonEditor/Main.vue
@@ -2,34 +2,38 @@
     <span>
         <div v-if="open" :style="element_style">
             <span v-if="render_object.type == 'object' || render_object.type == 'array'">
-                <draggable v-model="render_object.children" :options="{ group: 'key' }" @change="draggedKey">
-                <details 
-                    v-for="e in render_object.children"
-                    :key="e.uuid"
-                    :ref="`${object_key}/${(e.key + '').replace(/\//g, '#;slash;#')}`"
-                    :open="e.open"
+                <draggable 
+                    v-model="render_object.children"
+                    :options="{ group: 'key', disabled: $store.state.Settings.disable_node_dragging }"
+                    @change="draggedKey"
                 >
-                    <object-key 
-                        @mainClick="click($event, `load(${tab_id}):${object_key}/${e.key}`, e.key)"
-                        @arrowClick="$event.ctrlKey ? e.toggleOpenDeep() : e.toggleOpen()"
-                        :object="e"
-                        :my_key="e.key"
-                        :comment="e.comment"
-                        :object_key="`${object_key}/${(e.key + '').replace(/\//g, '#;slash;#')}`"
-                        :mark="e.mark_color"
-                        :error="e.error"
-                        :child_contains_error="e.child_contains_error"
-                        :node_context="e"
-                    />
+                    <details 
+                        v-for="e in render_object.children"
+                        :key="e.uuid"
+                        :ref="`${object_key}/${(e.key + '').replace(/\//g, '#;slash;#')}`"
+                        :open="e.open"
+                    >
+                        <object-key 
+                            @mainClick="click($event, `load(${tab_id}):${object_key}/${e.key}`, e.key)"
+                            @arrowClick="$event.ctrlKey ? e.toggleOpenDeep() : e.toggleOpen()"
+                            :object="e"
+                            :my_key="e.key"
+                            :comment="e.comment"
+                            :object_key="`${object_key}/${(e.key + '').replace(/\//g, '#;slash;#')}`"
+                            :mark="e.mark_color"
+                            :error="e.error"
+                            :child_contains_error="e.child_contains_error"
+                            :node_context="e"
+                        />
 
-                    <json-editor-main 
-                        :glob_object="first ? render_object : glob_object"
-                        :object="e"
-                        :first="false"
-                        :tab_id="tab_id"
-                        :object_key="`${object_key}/${(e.key + '').replace(/\//g, '#;slash;#')}`"
-                    />
-                </details>
+                        <json-editor-main 
+                            :glob_object="first ? render_object : glob_object"
+                            :object="e"
+                            :first="false"
+                            :tab_id="tab_id"
+                            :object_key="`${object_key}/${(e.key + '').replace(/\//g, '#;slash;#')}`"
+                        />
+                    </details>
                 </draggable>
             </span>
             

--- a/src/renderer/scripts/FileSystem.js
+++ b/src/renderer/scripts/FileSystem.js
@@ -22,7 +22,7 @@ document.addEventListener("drop", event => {
     event.preventDefault();
     let files = event.dataTransfer.files;
     if(files.length !== 0) win = new LoadingWindow("save-file").show();
-    console.log(event.dataTransfer.files)
+    // console.log(event.dataTransfer.files)
 
     setTimeout(() => {
         for(let file of files) {

--- a/src/renderer/windows/Settings.js
+++ b/src/renderer/windows/Settings.js
@@ -163,6 +163,11 @@ export default class SettingsWindow extends TabWindow {
                     text: "Word Wrap",
                     key: `settings.editor.tab.line_wraps.${Math.random()}`
                 }),
+                new ReactiveSwitch(this, "disable_node_dragging", {
+                    color: "light-green",
+                    text: "Disable Node Dragging",
+                    key: `settings.editor.tab.disable_node_dragging.${Math.random()}`
+                }),
                 new ReactiveSwitch(this, "focus_json_inputs", {
                     color: "light-green",
                     text: "Auto-Focus Inputs",


### PR DESCRIPTION
## Description
Makes JSON nodes draggable.

## Motivation and Context
This feature makes it easier to manage large JSON files. It's much faster to drag a node than to copying & pasting it manually.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My changes require updating to the plugin documentation.
