### PR TITLE
Add bridge logo and center title text in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
-# bridge.
-
-## Download
-#### [Latest version!](https://github.com/solvedDev/bridge./releases/latest)
+<h1 align="center">bridge.</h1>
+<p align="center">
+  <a href="https://github.com/solvedDev/bridge./releases/latest">
+    <img width="256" height="256" src="https://raw.githubusercontent.com/solvedDev/bridge./master/images/1024x1024.png">
+    <h4 align="center">Download the latest version</h4>
+  </a>
+</p>
 
 
 ## About bridge.


### PR DESCRIPTION
## Description
The bridge logo has been added to the `README.md` along with the title text getting centered. Unfortunately, centering text/images in markdown requires HTML to be directly inserted into the markdown file, but this is common practice. The download link has also been centered, allowing the user to just click the image (and the download text) as a quicker, more intuitive way to download the program.

## Motivation and Context
 - More aesthetically pleasing
 - Logo clickable to download the program
    - More intuitive

## Screenshots (if appropriate):
The result can be viewed [here](https://github.com/montudor/bridge/blob/docs/improve-readme/README.md)

## Types of changes
Just a visual change to the documentation.
